### PR TITLE
Treating generated go files as binaries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+pkg/generated/**/*.go binary


### PR DESCRIPTION
This should make genetated changes underneath `pkg/generated` easier to merge.