### PR TITLE
fix sdsApplication name generation

### DIFF
--- a/internal/cluster-manager-api/helm.go
+++ b/internal/cluster-manager-api/helm.go
@@ -60,7 +60,7 @@ func (s *Server) InstallHelmChart(ctx context.Context, in *pb.InstallHelmChartMs
 		return &pb.InstallHelmChartReply{}, fmt.Errorf("cluster %s is not ready for a request to provision tiller", in.Cluster)
 	}
 
-	err = s.cmak8s.UpdateOrCreateApplication(in.Chart.Name, cmak8sutil.Application{
+	err = s.cmak8s.UpdateOrCreateApplication(in.Chart.Name, in.PackageManger, cmak8sutil.Application{
 		CallbackURL: in.Callback.Url,
 		Cluster:     in.Cluster,
 		Chart: cmak8sutil.Chart{

--- a/pkg/util/k8sutil/cma/application.go
+++ b/pkg/util/k8sutil/cma/application.go
@@ -5,8 +5,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (c *Client) CreateApplication(name string, application Application) error {
-	adjustedName := c.getAdjustedName(name, application.Cluster)
+func (c *Client) CreateApplication(name string, packageManager string, application Application) error {
+	adjustedName := c.getAdjustedApplicationName(name, packageManager, application.Cluster)
 
 	annotations := make(map[string]string)
 	annotations[CallbackURLAnnotation] = application.CallbackURL
@@ -66,11 +66,11 @@ func (c *Client) GetApplication(name string, packageManager string, clusterName 
 	}, nil
 }
 
-func (c *Client) UpdateOrCreateApplication(name string, application Application) error {
-	result, err := c.getApplicationRaw(c.getAdjustedName(name, application.Cluster))
+func (c *Client) UpdateOrCreateApplication(name string, packageManager string, application Application) error {
+	result, err := c.getApplicationRaw(c.getAdjustedApplicationName(name, packageManager, application.Cluster))
 	if err != nil {
 		// Let's assume there is no application, so we create it
-		return c.CreateApplication(name, application)
+		return c.CreateApplication(name, packageManager, application)
 	}
 
 	result.Annotations[CallbackURLAnnotation] = application.CallbackURL

--- a/pkg/util/k8sutil/cma/interfaces.go
+++ b/pkg/util/k8sutil/cma/interfaces.go
@@ -20,9 +20,9 @@ type Client struct {
 }
 
 type ClientInterface interface {
-	CreateApplication(name string, application Application) error
+	CreateApplication(name string, packageManager string, application Application) error
 	GetApplication(name string, packageManager string, clusterName string) (Application, error)
-	UpdateOrCreateApplication(name string, application Application) error
+	UpdateOrCreateApplication(name string, packageManager string, application Application) error
 	DeleteApplication(name string, packageManager string, clusterName string) error
 	ChangeApplicationStatus(name string, packageManager string, clusterName string, status string) error
 


### PR DESCRIPTION
sdsApplication name generation was using `getAdjustedApplicationName` for some calls and `getAdjustedName` for others. Set all calls to use `getAdjustedApplicationName`