### PR TITLE
update cma-ssh value to align with the default

### DIFF
--- a/deployments/helm/cluster-manager-api/values.yaml
+++ b/deployments/helm/cluster-manager-api/values.yaml
@@ -41,5 +41,5 @@ helpers:
       insecure: true
    ssh:
       enabled: false
-      endpoint: cma-ssh-cma-ssh:80
+      endpoint: cma-ssh:80
       insecure: true


### PR DESCRIPTION
This update is to better align the default values in cma with the default values in its helper repos. Currently cma-ssh creates a service with the name `cma-ssh`. This update will help make the `cluster-manager-api` install via defaults work correctly. 